### PR TITLE
getDrama now uses my drama generator

### DIFF
--- a/src/main/java/com/harry2258/Alfred/api/Utils.java
+++ b/src/main/java/com/harry2258/Alfred/api/Utils.java
@@ -372,8 +372,8 @@ public class Utils {
     public static String getDrama() {
         String drama = null;
         try {
-            Document doc = Jsoup.connect("http://asie.pl/drama.php?2").get();
-            drama = doc.body().getElementsByTag("h1").text();
+            Document doc = Jsoup.connect("mc-drama.herokuapp.com").get();
+            drama = doc.body().getElementsByTag("h2").text();
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Fix #7 

I switched the code to use my drama generator, at http://mc-drama.herokuapp.com/ (source: https://github.com/elifoster/drama-rb), because it's the only one, aside from the Twitter one, that I know of that actually creates dramatic events.