### PR TITLE
Rewrite getDrama for the raw API.

### DIFF
--- a/src/main/java/com/harry2258/Alfred/api/Utils.java
+++ b/src/main/java/com/harry2258/Alfred/api/Utils.java
@@ -373,8 +373,9 @@ public class Utils {
     public static String getDrama() {
         String drama = null;
         try {
-            Document doc = Jsoup.connect("http://mc-drama.herokuapp.com/").get();
-            drama = doc.body().getElementsByTag("h2").text();
+            URL url = new URL("http://mc-drama.herokuapp.com/raw");
+            BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream()));
+            drama = in.readLine();
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This change is essentially the same as the recent update to my DramaSplash mod, and actually uses the same code essentially. 

Using the raw URL instead of parsing the main page will improve performance for obvious reasons.